### PR TITLE
Webサーバーコンテナを追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,12 @@ services:
     build: ./infra/php
     volumes:
       - ./backend:/work
+
+  web:
+    image: nginx:1.20-alpine
+    ports:
+      - 8080:80
+    volumes:
+      - ./backend:/work
+      - ./infra/nginx/default.conf:/etc/nginx/conf.d/default.conf
+    working_dir: /work

--- a/infra/nginx/default.conf
+++ b/infra/nginx/default.conf
@@ -1,0 +1,32 @@
+server {
+    listen 80;
+    server_name example.com;
+    root /work/public;
+
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Content-Type-Options "nosniff";
+
+    index index.html index.htm index.php;
+
+    charset utf-8;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    error_page 404 /index.php;
+
+    location ~ \.php$ {
+        fastcgi_pass app:9000;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    location ~ /\.(?!well-known).* {
+        deny all;
+    }
+}


### PR DESCRIPTION
webサーバーを追加

nginxのバージョンは偶数ナンバーがstableとされてる。

今回alpineを使っているのは、imageの容量が小さいから。（laravelはただでさえ容量がデカいので、少しでも容量を節約できるのなら節約したい。）

https://hub.docker.com/_/nginx

7/17現在の内容を見て、

```
 image: nginx:1.20-alpine
```

このイメージを使用することにした。





laravel6系のnginx設定例

これを参考に追加

laravelの公式ドキュメント

参考：https://readouble.com/laravel/6.x/ja/deployment.html

Infra/nginx/default.conf



nginxでphpを動かす

参考：https://bit.ly/2VNWdfL

このあたりも見とく↓↓

- [nginx beginners_guide](http://nginx.org/en/docs/beginners_guide.html)
- [Nginx設定のまとめ](https://qiita.com/syou007/items/3e2d410bbe65a364b603)
- [nginxについてまとめ(設定編)](https://qiita.com/morrr/items/7c97f0d2e46f7a8ec967)



コンテナを立ち上げて、

```
docker compose up -d
```



どのコンテナが立ち上がっているかを確認

```
docker compose ps
```



nginxのバージョンを確認

```
[mac] $ docker compose exec web nginx -v
nginx version: nginx/1.20.1
```



Webコンテナが無事動いてるかをサンプルファイルを作成して確認



動かない



確認する

参考：https://web.plus-idea.net/on/docker-web-server-access-denied/



Default.confのrootがミスってた。

laravelのnginxの参考サイトをそのままコピペしちゃってた。docker-compose.ymlをちゃんとみること。



動いた。

サンプルコードも表示を確認